### PR TITLE
Add bt-render CLI script

### DIFF
--- a/blendertoolbox/cli.py
+++ b/blendertoolbox/cli.py
@@ -1,0 +1,38 @@
+import argparse
+
+
+def main(argv=None):
+    """Command-line interface for BlenderToolbox rendering."""
+    parser = argparse.ArgumentParser(
+        description="Render a mesh with Blender Toolbox")
+    parser.add_argument(
+        "mesh",
+        help="Path to mesh file (.obj, .ply, etc.)")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="render.png",
+        help="Output image path")
+    args = parser.parse_args(argv)
+
+    import blendertoolbox as bt
+
+    arguments = {
+        "output_path": args.output,
+        "image_resolution": [720, 720],
+        "number_of_samples": 200,
+        "mesh_path": args.mesh,
+        "mesh_position": (1.12, -0.14, 0),
+        "mesh_rotation": (90, 0, 227),
+        "mesh_scale": (1.5, 1.5, 1.5),
+        "shading": "smooth",
+        "subdivision_iteration": 0,
+        "mesh_RGB": [144.0 / 255, 210.0 / 255, 236.0 / 255],
+        "light_angle": (6, -30, -155),
+    }
+
+    bt.render_mesh_default(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='blendertoolbox',
-    version='0.0.5',
+    version='0.0.6',
     description='Some Blender functions for rendering paper figures',
     url='https://github.com/HTDerekLiu/BlenderToolbox/',
     author='Hsueh-Ti Derek Liu',
@@ -10,6 +10,11 @@ setup(
     license='Apache 2.0',
     packages=['blendertoolbox'],
     install_requires=[ ],
+    entry_points={
+        'console_scripts': [
+            'bt-render=blendertoolbox.cli:main',
+        ],
+    },
     classifiers=[
         'Programming Language :: Python :: 3.10',
     ],


### PR DESCRIPTION
## Summary
- create `blendertoolbox/cli.py` with a simple command-line interface
- expose new `bt-render` console script via setuptools entry point
- bump package version to `0.0.6`

## Testing
- `python -m py_compile blendertoolbox/cli.py`
- `python -m py_compile setup.py`
- `python setup.py --version`

------
https://chatgpt.com/codex/tasks/task_e_6861e62675948330bdc604c1678b7f9a