### PR TITLE
Fix CI workflow by updating artifact actions

### DIFF
--- a/.github/workflows/ciwheels.yml
+++ b/.github/workflows/ciwheels.yml
@@ -30,7 +30,7 @@ jobs:
           pip install sdist_check 
           python setup.py sdist_check
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
 
@@ -171,7 +171,7 @@ jobs:
       #     python -m delvewheel repair *.whl
 
       # Upload binaries to github
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             ./dist/*.whl 
@@ -186,7 +186,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
## Summary
- update deprecated `actions/upload-artifact` to v4
- update `actions/download-artifact` to v4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ea0067948330817c0ec6bd60d550