### PR TITLE
Add numpy requirement and clarify bpy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ source activate blender
 pip install blendertoolbox
 pip install bpy
 ```
+The `bpy` package is not installed automatically and must be installed manually as shown above. Dependencies such as `numpy` will be pulled in when installing `blendertoolbox`.
 Please make sure you're using python 3.10, as Blender Python `bpy` is only compiled for that version of python.
 
 Once it is installed successfully, one can simply type in, e.g.,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='hsuehtil@gmail.com',
     license='Apache 2.0',
     packages=['blendertoolbox'],
-    install_requires=[ ],
+    install_requires=['numpy'],
     classifiers=[
         'Programming Language :: Python :: 3.10',
     ],


### PR DESCRIPTION
## Summary
- note `bpy` must be installed manually
- list numpy in `install_requires`
- provide `pyproject.toml` so setuptools and wheel are installed for builds

## Testing
- `pip install -e .`
- `pip check`
- `python -m build --sdist --wheel -n`


------
https://chatgpt.com/codex/tasks/task_e_6861e794c564833094637f62e0c1b471